### PR TITLE
fix: add argparser, lint, typing, and improve converter

### DIFF
--- a/alkana/__init__.py
+++ b/alkana/__init__.py
@@ -4,5 +4,5 @@
 # (c) 2019 cod
 
 
-from .main import get_kana
-from .external_data import add_external_data
+from .external_data import add_external_data  # noqa: E261,F401
+from .main import get_kana  # noqa: E261,F401

--- a/alkana/console.py
+++ b/alkana/console.py
@@ -3,14 +3,32 @@
 # Licence GPLv2
 # (c) 2019 cod
 
+import argparse
+
+from .main import get_kana
+
+
+def parse_args(test=None):
+    """Parse arguments."""
+    parser = argparse.ArgumentParser(
+        prog='alkana',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="A tool to get the katakana reading of an alphabetical string"
+    )
+
+    parser.add_argument('word', metavar='word', type=str,
+                        help='The alphabetical string you want to get the katakana reading')
+    # parser.add_argument('-V', '--version', action='version',
+    #                     version='%(prog)s {}'.format(__version__))
+    if test:
+        return parser.parse_args(test)
+    else:
+        return parser.parse_args()
+
 
 def console():
-    import sys
-    from .main import get_kana
-
-    if len(sys.argv) != 2:
-        print('usage: alkana <word>')
-        sys.exit()
-    result = get_kana(sys.argv[1])
+    # type: () -> None
+    args = parse_args()
+    result = get_kana(args.word)
     if result:
         print(result)

--- a/alkana/data.py
+++ b/alkana/data.py
@@ -6,8 +6,8 @@
 # Original data: bep-eng.dic
 # (c) 1999-2002 Bilingual Emacspeak Project
 
-
-data = {
+# type: dict[str, str]
+data = {  # noqa: F601
     "zyuganov": 'ジュガノフ',
     "zygote": 'ザイゴウト',
     "zygomatic": 'ザイゴウマティク',

--- a/alkana/external_data.py
+++ b/alkana/external_data.py
@@ -6,6 +6,7 @@ from .data import data
 
 
 def add_external_data(file_path):
+    # type: (str) -> None
     external_data = {}
     with open(file_path, 'r') as f:
         for x in f:

--- a/alkana/main.py
+++ b/alkana/main.py
@@ -2,10 +2,13 @@
 #
 # Licence GPLv2
 # (c) 2019 cod
+from re import sub
+
 from .data import data
 
 
 def get_kana(word):
+    # type: (str) -> str | None
     """
     Returns the reading of `word` as katakana.
 
@@ -22,6 +25,9 @@ def get_kana(word):
         `None` if reading is not found.
     """
     try:
-        return data[word.lower()]
+        return sub(
+            r'[a-z]+',
+            lambda s: data[s.group(0)],
+            str(word).lower())
     except KeyError:
         return None

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@
 # coding: utf-8
 
 
-import setuptools
 import pathlib
 
+import setuptools
 
 description = 'A tool to get the katakana reading of an alphabetical string.'
 readme_file = pathlib.Path(__file__).parent/'README.md'
@@ -29,7 +29,7 @@ setuptools.setup(
         'Development Status :: 3 - Alpha',
         'Programming Language :: Python :: 3.6',
         'Natural Language :: Japanese',
-        'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',  # noqa
+        'License :: OSI Approved :: GNU General Public License v2 (GPLv2)'
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
```bash
$ git clone --depth 1 https://github.com/eggplants/alkana.py
$ cd alkana.py
$ python -m pip install -e .
...
$ alkana
usage: alkana [-h] word
alkana: error: the following arguments are required: word
$ alkana -h
usage: alkana [-h] word

A tool to get the katakana reading of an alphabetical string

positional arguments:
  word        The alphabetical string you want to get the katakana reading

optional arguments:
  -h, --help  show this help message and exit
$ alkana Hello,\ codさん！
ハロー, コッドさん！
$ alkana invalidwordsequence
$ alkana valid word sequence
ヴァリッド ワード シークェンス
```

`get_kana`で`KeyError`の際に`ValueError("%s is not in data."%word)`を返させてもいいと思います。